### PR TITLE
Merge when importing state file

### DIFF
--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -236,7 +236,6 @@ class ImportStateFiles(ConfigOp):
             raise ActionError(os.path.basename(source_file) + " " +
                               repr(traceback.format_exception(*sys.exc_info()))
                               .split("Error:", 1)[1].replace("\\n", "").replace("']", ""))
-        sys.exc_clear()
 
     def run_create_state(self, trans, source_file, state_file, flags):
         trans.load_config(flags, source_file)
@@ -265,7 +264,6 @@ class CheckStates(ConfigOp):
                 failures.append("\n"+self.state_filename_to_name(filename) + " " +
                                 repr(traceback.format_exception(*sys.exc_info()))
                                 .split("Error:", 1)[1].replace("\\n", "").replace("']", ""))
-                sys.exc_clear()
         if failures == []:
             return {'success': 'all states are consistent'}
         else:

--- a/python/drned_xmnr/op/config_op.py
+++ b/python/drned_xmnr/op/config_op.py
@@ -122,8 +122,8 @@ class ImportStateFiles(ConfigOp):
     def _init_params(self, params):
         self.pattern = params.file_path_pattern
         self.file_format = self.param_default(params, "format", "")
-        self.overwrite =  self.param_default(params, "overwrite", "")
-        self.merge =  self.param_default(params, "merge", "")
+        self.overwrite = params.overwrite
+        self.merge = params.merge
 
     def perform(self):
         filenames = glob.glob(self.pattern)
@@ -230,8 +230,8 @@ class ImportStateFiles(ConfigOp):
     def create_state(self, source_file, state_file, flags):
         try:
             self.run_with_trans(lambda trans: self.run_create_state(trans, source_file, state_file,
-                                                                flags),
-                                write=True, no_commit=True)
+                                                                    flags), write=True,
+                                no_commit=True)
         except Exception:
             raise ActionError(os.path.basename(source_file) + " " +
                               repr(traceback.format_exception(*sys.exc_info()))
@@ -251,7 +251,7 @@ class CheckStates(ConfigOp):
     action_name = 'check states'
 
     def _init_params(self, params):
-        self.validate = self.param_default(params, "validate", "")
+        self.validate = params.validate
 
     def perform(self):
         states = self.get_states()

--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -174,6 +174,12 @@ module drned-xmnr {
               type boolean;
               default false;
             }
+            leaf merge {
+              tailf:info "Merge the file(s) with the current configuration
+                          before creating the XMNR state file.";
+              type boolean;
+              default false;
+            }
           }
           output {
             uses action-output-common;
@@ -187,9 +193,10 @@ module drned-xmnr {
           input {
             leaf validate {
               tailf:info
-                "In addition to checking against the device model.
+                "In addition to checking against the device model,
                   validate with the current configuration.";
-              type empty;
+              type boolean;
+              default false;
             }
           }
           output {


### PR DESCRIPTION
Added a merge option (default false) to the import state files command. This feature will make it possible to have a partial configuration test vector and merge it (instead of the default replacing) with the existing configuration before creating an xmnr state file. 

The default replace option requires that you had all the necessary configuration in the state file in order to import and use it for transition tests. Having a merge option enables one to keep minimal configuration states that are portable/sharable between different systems without editing the state files. 
