### PR TITLE
xml-save - added format to record-state action (c-style, xml)

### DIFF
--- a/src/yang/drned-xmnr.yang
+++ b/src/yang/drned-xmnr.yang
@@ -114,6 +114,13 @@ module drned-xmnr {
               }
               default 0;
             }
+            leaf format {
+              type enumeration {
+                enum xml;
+                enum c-style;
+              }
+              default c-style;
+            }
           }
           output {
             uses action-output-common;
@@ -310,7 +317,7 @@ module drned-xmnr {
         container data {
           config false;
           tailf:callpoint coverage-data;
-          
+
           leaf nodes-total {
             type uint32;
           }


### PR DESCRIPTION
Added support to record state in XML format (accepted by DRNED).

E.g.:

```
drned-xmnr state record-state state-name a1 format xml
drned-xmnr transitions transition-to-state state-name a1
```