### PR TITLE
using --unreserved conditionally

### DIFF
--- a/python/drned_xmnr/op/base_op.py
+++ b/python/drned_xmnr/op/base_op.py
@@ -40,6 +40,7 @@ class XmnrBase(object):
         self.log_filename = root.drned_xmnr.xmnr_log_file
         self.dev_test_dir = os.path.join(self.xmnr_directory, self.dev_name, 'test')
         self.drned_run_directory = os.path.join(self.dev_test_dir, 'drned-skeleton')
+        self.using_builtin_drned = root.drned_xmnr.drned_directory == "builtin"
         self.states_dir = os.path.join(self.dev_test_dir, 'states')
         try:
             os.makedirs(self.states_dir)

--- a/python/drned_xmnr/op/transitions_op.py
+++ b/python/drned_xmnr/op/transitions_op.py
@@ -47,7 +47,9 @@ class TransitionsOp(base_op.ActionBase):
         return filtering.build_filter(self, level, writer)
 
     def drned_run(self, drned_args, timeout=120):
-        args = ["-s", "--tb=short", "--device="+self.dev_name, "--unreserved"] + drned_args
+        args = ["-s", "--tb=short", "--device="+self.dev_name] + drned_args
+        if not self.using_builtin_drned:
+            args.append("--unreserved")
         args.insert(0, "py.test")
         self.log.debug("drned: {0}".format(args))
         return self.run_in_drned_env(args, timeout)


### PR DESCRIPTION
The code uses `--unreserved` when starting tests, but this fails when using the builtin DrNED. The patch fixes that.